### PR TITLE
added the 'hide dimensions' property to the editor

### DIFF
--- a/src/Dawoe.OEmbedPickerPropertyEditor.Web/App_Plugins/Dawoe.OEmbedPickerPropertyEditor/package.manifest
+++ b/src/Dawoe.OEmbedPickerPropertyEditor.Web/App_Plugins/Dawoe.OEmbedPickerPropertyEditor/package.manifest
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/package.manifest",
-  "javascript": [
-    "~/App_Plugins/Dawoe.OEmbedPickerPropertyEditor/scripts/editor.controller.js"
-  ]
+	"javascript": [
+		"~/App_Plugins/Dawoe.OEmbedPickerPropertyEditor/scripts/editor.controller.js",
+		"~/App_Plugins/Dawoe.OEmbedPickerPropertyEditor/scripts/embed.controller.js"
+	]
 }

--- a/src/Dawoe.OEmbedPickerPropertyEditor.Web/App_Plugins/Dawoe.OEmbedPickerPropertyEditor/scripts/editor.controller.js
+++ b/src/Dawoe.OEmbedPickerPropertyEditor.Web/App_Plugins/Dawoe.OEmbedPickerPropertyEditor/scripts/editor.controller.js
@@ -1,17 +1,18 @@
-﻿(function() {
+﻿(function () {
     'use strict';
 
     function EditorController($scope, $sce, editorService) {
         var vm = this;
 
         vm.allowMultiple = $scope.model.config.allowmultiple;
+        vm.hideDimensions = $scope.model.config.hidedimensions;
 
         vm.items = Array.isArray($scope.model.value) ? $scope.model.value : [];
 
-        function openEmbedDialog(embed, onSubmit) {
-
-            const embedDialog = {
-                embed: _.clone(embed),
+        function openEmbedDialog(onSubmit) {
+            const options = {
+                view: '/App_Plugins/Dawoe.OEmbedPickerPropertyEditor/views/embed.html',
+                hideDimensions: vm.hideDimensions,
                 submit: function (model) {
                     onSubmit(model.embed);
                     editorService.close();
@@ -21,8 +22,7 @@
                 }
             };
 
-            editorService.embed(embedDialog);
-
+            editorService.open(options);
         }
 
         function trustHtml(html) {
@@ -32,17 +32,16 @@
         function addEmbed(evt) {
             evt.preventDefault();
 
-            openEmbedDialog({},
-                (newEmbed) => {
+            openEmbedDialog((newEmbed) => {
                     vm.items.push({
                         'url': newEmbed.url,
                         'width': newEmbed.width,
                         'height': newEmbed.height,
-                        'preview' : newEmbed.preview
+                        'preview': newEmbed.preview
                     });
                     updateModelValue();
                 });
-        }    
+        }
 
         function removeEmbed(index, evt) {
             evt.preventDefault();

--- a/src/Dawoe.OEmbedPickerPropertyEditor.Web/App_Plugins/Dawoe.OEmbedPickerPropertyEditor/scripts/embed.controller.js
+++ b/src/Dawoe.OEmbedPickerPropertyEditor.Web/App_Plugins/Dawoe.OEmbedPickerPropertyEditor/scripts/embed.controller.js
@@ -1,0 +1,151 @@
+﻿(function () {
+    "use strict";
+
+    function embedController($scope, $http, $sce, umbRequestHelper, localizationService) {
+
+        var vm = this;
+        var origWidth = 500;
+        var origHeight = 300;
+
+        vm.loading = false;
+        vm.trustedPreview = null;
+        vm.hideDimensions = $scope.model.hideDimensions;
+
+        $scope.model.embed = {
+            url: "",
+            width: 360,
+            height: 240,
+            constrain: true,
+            preview: "",
+            success: false,
+            info: "",
+            supportsDimensions: false
+        };
+
+        if ($scope.model.modify) {
+            angular.extend($scope.model.embed, $scope.model.modify);
+
+            showPreview();
+        }
+
+        vm.toggleConstrain = toggleConstrain;
+        vm.showPreview = showPreview;
+        vm.changeSize = changeSize;
+        vm.submit = submit;
+        vm.close = close;
+
+        function onInit() {
+            if (!$scope.model.title) {
+                localizationService.localize("general_embed").then(function (value) {
+                    $scope.model.title = value;
+                });
+            }
+        }
+
+        function showPreview() {
+
+            if ($scope.model.embed.url) {
+                $scope.model.embed.show = true;
+                $scope.model.embed.info = "";
+                $scope.model.embed.success = false;
+
+                vm.loading = true;
+
+                $http({
+                    method: 'GET',
+                    url: umbRequestHelper.getApiUrl("embedApiBaseUrl", "GetEmbed"),
+                    params: {
+                        url: $scope.model.embed.url,
+                        width: $scope.model.embed.width,
+                        height: $scope.model.embed.height
+                    }
+                }).then(function (response) {
+
+                    $scope.model.embed.preview = "";
+
+                    switch (response.data.OEmbedStatus) {
+                        case 0:
+                            //not supported
+                            $scope.model.embed.preview = "";
+                            $scope.model.embed.info = "Not supported";
+                            $scope.model.embed.success = false;
+                            $scope.model.embed.supportsDimensions = false;
+                            vm.trustedPreview = null;
+                            break;
+                        case 1:
+                            //error
+                            $scope.model.embed.preview = "";
+                            $scope.model.embed.info = "Could not embed media - please ensure the URL is valid";
+                            $scope.model.embed.success = false;
+                            $scope.model.embed.supportsDimensions = false;
+                            vm.trustedPreview = null;
+                            break;
+                        case 2:
+                            $scope.model.embed.success = true;
+                            $scope.model.embed.supportsDimensions = response.data.SupportsDimensions;
+                            $scope.model.embed.preview = response.data.Markup;
+                            vm.trustedPreview = $sce.trustAsHtml(response.data.Markup);
+                            break;
+                    }
+
+                    vm.loading = false;
+
+                }, function () {
+                    $scope.model.embed.success = false;
+                    $scope.model.embed.supportsDimensions = false;
+                    $scope.model.embed.preview = "";
+                    $scope.model.embed.info = "Could not embed media - please ensure the URL is valid";
+
+                    vm.loading = false;
+                });
+            } else {
+                $scope.model.embed.supportsDimensions = false;
+                $scope.model.embed.preview = "";
+                $scope.model.embed.info = "Please enter a URL";
+            }
+        }
+
+        function changeSize(type) {
+
+            var width, height;
+
+            if ($scope.model.embed.constrain) {
+                width = parseInt($scope.model.embed.width, 10);
+                height = parseInt($scope.model.embed.height, 10);
+                if (type == 'width') {
+                    origHeight = Math.round((width / origWidth) * height);
+                    $scope.model.embed.height = origHeight;
+                } else {
+                    origWidth = Math.round((height / origHeight) * width);
+                    $scope.model.embed.width = origWidth;
+                }
+            }
+            if ($scope.model.embed.url !== "") {
+                showPreview();
+            }
+
+        }
+
+        function toggleConstrain() {
+            $scope.model.embed.constrain = !$scope.model.embed.constrain;
+        }
+
+        function submit() {
+            if ($scope.model && $scope.model.submit) {
+                $scope.model.submit($scope.model);
+            }
+        }
+
+        function close() {
+            if ($scope.model && $scope.model.close) {
+                $scope.model.close();
+            }
+        }
+
+        onInit();
+
+    }
+
+    angular.module("umbraco").controller("Umbraco.OEmbedEmbedController", embedController);
+
+})();

--- a/src/Dawoe.OEmbedPickerPropertyEditor.Web/App_Plugins/Dawoe.OEmbedPickerPropertyEditor/views/editor.html
+++ b/src/Dawoe.OEmbedPickerPropertyEditor.Web/App_Plugins/Dawoe.OEmbedPickerPropertyEditor/views/editor.html
@@ -3,7 +3,7 @@
         <div class="umb-table">
             <div class="umb-table-body" ui-sortable="sortableOptions" ng-model="vm.items">
                 <div class="umb-table-row" ng-repeat="embed in vm.items track by $index">
-                    <div class="umb-table-cell">
+                    <div class="umb-table-cell" ng-show="vm.allowMultiple === true && vm.items.length > 1">
                         <i class="icon icon-navigation handle"></i>
                     </div>
                     <div class="umb-table-cell umb-table-cell--auto-width">

--- a/src/Dawoe.OEmbedPickerPropertyEditor.Web/App_Plugins/Dawoe.OEmbedPickerPropertyEditor/views/embed.html
+++ b/src/Dawoe.OEmbedPickerPropertyEditor.Web/App_Plugins/Dawoe.OEmbedPickerPropertyEditor/views/embed.html
@@ -1,0 +1,77 @@
+﻿<div ng-controller="Umbraco.OEmbedEmbedController as vm">
+    <form name="embedForm">
+
+        <umb-editor-view>
+
+            <umb-editor-header name="model.title"
+                                                 name-locked="true"
+                                                 hide-alias="true"
+                                                 hide-icon="true"
+                                                 hide-description="true">
+            </umb-editor-header>
+
+            <umb-editor-container class="block-form">
+                <umb-box>
+                    <umb-box-content>
+
+                        <umb-control-group label="@general_url">
+                            <input id="url" class="umb-property-editor input-block-level" type="text" style="margin-bottom: 10px;" ng-model="model.embed.url" ng-keyup="$event.keyCode == 13 ? vm.showPreview() : null" focus-when="{{true}}" required />
+                            <umb-button type="button"
+                                                    action="vm.showPreview()"
+                                                    button-style="info"
+                                                    label-key="general_retrieve">
+                            </umb-button>
+                        </umb-control-group>
+
+                        <umb-load-indicator ng-if="vm.loading"></umb-load-indicator>
+
+                        <div ng-if="!vm.loading">
+
+                            <umb-control-group>
+                                <p ng-bind="model.embed.info"></p>
+                                <div ng-bind-html="vm.trustedPreview"></div>
+                            </umb-control-group>
+
+                            <div ng-show="!vm.hideDimensions && model.embed.supportsDimensions && model.embed.success">
+                                <umb-control-group label="@general_width">
+                                    <input type="number" pattern="[0-9]*" min="0" ng-model="model.embed.width" ng-blur="vm.changeSize('width')" />
+                                </umb-control-group>
+
+                                <umb-control-group label="@general_height">
+                                    <input type="number" pattern="[0-9]*" min="0" ng-model="model.embed.height" ng-blur="vm.changeSize('height')" />
+                                </umb-control-group>
+
+                                <umb-control-group label="@general_constrain">
+                                    <umb-toggle checked="model.embed.constrain" on-click="vm.toggleConstrain()"></umb-toggle>
+                                </umb-control-group>
+                            </div>
+
+                        </div>
+
+                    </umb-box-content>
+                </umb-box>
+            </umb-editor-container>
+
+            <umb-editor-footer>
+                <umb-editor-footer-content-right>
+                    <umb-button type="button"
+                                            button-style="link"
+                                            label-key="general_close"
+                                            shortcut="esc"
+                                            action="vm.close()">
+                    </umb-button>
+                    <umb-button type="button"
+                                            button-style="success"
+                                            label-key="general_submit"
+                                            state="vm.saveButtonState"
+                                            disabled="!model.embed.url.length || !model.embed.preview.length"
+                                            action="vm.submit(model)">
+                    </umb-button>
+                </umb-editor-footer-content-right>
+            </umb-editor-footer>
+
+        </umb-editor-view>
+
+    </form>
+
+</div>

--- a/src/Dawoe.OEmbedPickerPropertyEditor.Web/Dawoe.OEmbedPickerPropertyEditor.Web.csproj
+++ b/src/Dawoe.OEmbedPickerPropertyEditor.Web/Dawoe.OEmbedPickerPropertyEditor.Web.csproj
@@ -150,6 +150,7 @@
   <ItemGroup>
     <None Include="app.config" />
     <None Include="App_Plugins\Dawoe.OEmbedPickerPropertyEditor\package.manifest" />
+    <Content Include="App_Plugins\Dawoe.OEmbedPickerPropertyEditor\scripts\embed.controller.js" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
@@ -161,6 +162,7 @@
   <ItemGroup>
     <Content Include="App_Plugins\Dawoe.OEmbedPickerPropertyEditor\scripts\editor.controller.js" />
     <Content Include="App_Plugins\Dawoe.OEmbedPickerPropertyEditor\views\editor.html" />
+    <Content Include="App_Plugins\Dawoe.OEmbedPickerPropertyEditor\views\embed.html" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\Umbraco.SqlServerCE.4.0.0.1\build\Umbraco.SqlServerCE.targets" Condition="Exists('..\packages\Umbraco.SqlServerCE.4.0.0.1\build\Umbraco.SqlServerCE.targets')" />

--- a/src/Dawoe.OEmbedPickerPropertyEditor/Configuration/OEmbedPickerConfiguration.cs
+++ b/src/Dawoe.OEmbedPickerPropertyEditor/Configuration/OEmbedPickerConfiguration.cs
@@ -12,5 +12,11 @@
         /// </summary>
         [ConfigurationField("allowmultiple", "Allow picking of multiple items", "boolean")]
         public bool AllowMultiple { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to hide the dimensions in the embed view
+        /// </summary>
+        [ConfigurationField("hidedimensions", "Hide dimensions", "boolean")]
+        public bool HideDimensions { get; set; }
     }
 }


### PR DESCRIPTION
hi dave,

i've been using the plugin in a number of projects now and it works a treat!

one request i've had though is to remove the dimension properties from the embed dialog as nearly all the sites i've used the plugin on are responsive and therefore the dimensions are controlled by the front end...

so i had a play and found the easiest way to get around this was to add a new property to the datatype setting a bool value for hiding the dimensions.

i then took the embed infinate editor view and code from the umbraco core and updated it to show/hide the dimensions based on the property editor value.

i've given it a good test through in the project i'm working on and so far, so good!

if you could take a look at the code and let me know if it'd be good to merge in for the next release, that'd be amazin ;)

oh, and one other minor tweak: i updated the editor to only output the sorting handle if the editor allows multiple items and has more than 1 item.