### PR TITLE
Updated the property's look and feel

### DIFF
--- a/src/Dawoe.OEmbedPickerPropertyEditor.Web/App_Plugins/Dawoe.OEmbedPickerPropertyEditor/css/editor.styles.css
+++ b/src/Dawoe.OEmbedPickerPropertyEditor.Web/App_Plugins/Dawoe.OEmbedPickerPropertyEditor/css/editor.styles.css
@@ -1,0 +1,72 @@
+/* Removes default spacing between inline-block items */
+.Dawoe-OEmbedPicker {
+	font-size: 0 
+}
+
+.Dawoe-OEmbedPicker .umb-sortable-thumbnails,
+.Dawoe-OEmbedPicker .items-container,
+.Dawoe-OEmbedPicker .picker-btn {
+	display: inline-block;
+	margin-bottom: 15px
+}
+
+.Dawoe-OEmbedPicker .umb-sortable-thumbnails,
+.Dawoe-OEmbedPicker .picker-btn {
+	border: 1px solid #d8d7d9;
+	margin-right: 30px;
+	padding: 20px;
+	vertical-align: top
+}
+
+/*
+	Eliminate default unecessary space at the bottom
+	Make preview smaller at a size equivalent to an HD size (at a smaller scale)
+*/
+.Dawoe-OEmbedPicker .preview-item span,
+.Dawoe-OEmbedPicker iframe {
+	height: 100px;
+}
+
+.Dawoe-OEmbedPicker iframe,
+.Dawoe-OEmbedPicker .add-link {
+	width: 178px;
+}
+
+.Dawoe-OEmbedPicker .preview-item span { 
+	display: block;
+}
+
+/* Re-position and style action buttons */
+.Dawoe-OEmbedPicker .umb-sortable-thumbnails {
+	position: relative
+}
+
+.Dawoe-OEmbedPicker .sort-icon {
+	cursor: move;
+	font-size: 16px;
+	left: 0;
+	padding: 4px;
+	position: absolute;
+	top: 0
+}
+
+.Dawoe-OEmbedPicker .umb-node-preview__action {
+	background: #fff;
+	border-radius: 100%;
+	box-shadow: 0 1px 2px rgba(0,0,0,.25);
+	color: #d42054;
+	font-size: 16px;
+    height: 25px;
+    line-height: 26px;
+	position: absolute;
+	right: -18px;
+	text-align: center;
+	text-decoration: none;
+	top: -12px;
+    width: 25px
+}
+
+/* Overwrite default margin */
+.Dawoe-OEmbedPicker.umb-mediapicker .add-link-square {
+	margin: 0
+}

--- a/src/Dawoe.OEmbedPickerPropertyEditor.Web/App_Plugins/Dawoe.OEmbedPickerPropertyEditor/package.manifest
+++ b/src/Dawoe.OEmbedPickerPropertyEditor.Web/App_Plugins/Dawoe.OEmbedPickerPropertyEditor/package.manifest
@@ -2,5 +2,8 @@
   "$schema": "http://json.schemastore.org/package.manifest",
   "javascript": [
     "~/App_Plugins/Dawoe.OEmbedPickerPropertyEditor/scripts/editor.controller.js"
+  ],
+  "css": [
+	"~/App_Plugins/Dawoe.OEmbedPickerPropertyEditor/css/editor.styles.css"
   ]
 }

--- a/src/Dawoe.OEmbedPickerPropertyEditor.Web/App_Plugins/Dawoe.OEmbedPickerPropertyEditor/views/editor.html
+++ b/src/Dawoe.OEmbedPickerPropertyEditor.Web/App_Plugins/Dawoe.OEmbedPickerPropertyEditor/views/editor.html
@@ -2,15 +2,15 @@
 	<ng-form name="vm.oembedform">
 		<div ui-sortable="sortableOptions" ng-model="vm.items" class="items-container" ng-hide="!model.value">
 			<div class="umb-sortable-thumbnails umb-table-row" ng-repeat="embed in vm.items track by $index">
-				<div class="sort-icon"><i class="icon icon-navigation handle"></i></div>
+				<div class="sort-icon" ng-if="vm.allowMultiple === true && vm.items.length > 1"><i class="icon icon-navigation handle"></i></div>
 				<div class="preview-item">
 					<span ng-bind-html="vm.trustHtml(embed.preview)"></span>
 				</div>
 				<a class="umb-node-preview__action umb-node-preview__action--red" ng-click="vm.remove($index, $event)"><i class="icon icon-delete"></i></a>
 			</div>
 		</div>
-		<div class="picker-btn">
-			<button type="button" class="add-link btn-reset umb-outline umb-outline--surrounding add-link-square" ng-click="vm.add($event)" ng-hide="vm.allowMultiple === false && vm.items.length == 1"><i class="icon icon-add large"></i></button>
+		<div class="picker-btn" ng-if="vm.allowMultiple === true && vm.items.length > 1">
+			<button type="button" class="add-link btn-reset umb-outline umb-outline--surrounding add-link-square" ng-click="vm.add($event)"><i class="icon icon-add large"></i></button>
 		</div>
 		<input type="hidden" name="itemCount" ng-model="vm.items.length" val-property-validator="vm.validateMandatory" />
 	</ng-form>

--- a/src/Dawoe.OEmbedPickerPropertyEditor.Web/App_Plugins/Dawoe.OEmbedPickerPropertyEditor/views/editor.html
+++ b/src/Dawoe.OEmbedPickerPropertyEditor.Web/App_Plugins/Dawoe.OEmbedPickerPropertyEditor/views/editor.html
@@ -9,7 +9,7 @@
 				<a class="umb-node-preview__action umb-node-preview__action--red" ng-click="vm.remove($index, $event)"><i class="icon icon-delete"></i></a>
 			</div>
 		</div>
-		<div class="picker-btn" ng-if="vm.allowMultiple === true && vm.items.length > 1">
+		<div class="picker-btn" ng-hide="vm.allowMultiple === false && vm.items.length == 1">
 			<button type="button" class="add-link btn-reset umb-outline umb-outline--surrounding add-link-square" ng-click="vm.add($event)"><i class="icon icon-add large"></i></button>
 		</div>
 		<input type="hidden" name="itemCount" ng-model="vm.items.length" val-property-validator="vm.validateMandatory" />

--- a/src/Dawoe.OEmbedPickerPropertyEditor.Web/App_Plugins/Dawoe.OEmbedPickerPropertyEditor/views/editor.html
+++ b/src/Dawoe.OEmbedPickerPropertyEditor.Web/App_Plugins/Dawoe.OEmbedPickerPropertyEditor/views/editor.html
@@ -1,26 +1,17 @@
-﻿<div ng-controller="Dawoe.OEmbedPickerEditorController as vm">
-    <ng-form name="vm.oembedform">
-        <div class="umb-table">
-            <div class="umb-table-body" ui-sortable="sortableOptions" ng-model="vm.items">
-                <div class="umb-table-row" ng-repeat="embed in vm.items track by $index">
-                    <div class="umb-table-cell">
-                        <i class="icon icon-navigation handle"></i>
-                    </div>
-                    <div class="umb-table-cell umb-table-cell--auto-width">
-
-                        <span ng-bind-html="vm.trustHtml(embed.preview)"></span>
-
-                    </div>
-
-                    <div class="umb-table-cell">
-                        <a class="umb-node-preview__action umb-node-preview__action--red" ng-click="vm.remove($index, $event)"><localize key="general_remove">Remove</localize></a>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <umb-button action="vm.add($event)" type="button" button-style="action" label="Add item" label_key="general_add" add-ellipsis="true" ng-hide="vm.allowMultiple === false && vm.items.length == 1"></umb-button>
-
-        <input type="hidden" name="itemCount" ng-model="vm.items.length" val-property-validator="vm.validateMandatory" />
-    </ng-form>
+﻿<div ng-controller="Dawoe.OEmbedPickerEditorController as vm" class="Dawoe-OEmbedPicker umb-property-editor umb-mediapicker umb-mediapicker-multiple">
+	<ng-form name="vm.oembedform">
+		<div ui-sortable="sortableOptions" ng-model="vm.items" class="items-container" ng-hide="!model.value">
+			<div class="umb-sortable-thumbnails umb-table-row" ng-repeat="embed in vm.items track by $index">
+				<div class="sort-icon"><i class="icon icon-navigation handle"></i></div>
+				<div class="preview-item">
+					<span ng-bind-html="vm.trustHtml(embed.preview)"></span>
+				</div>
+				<a class="umb-node-preview__action umb-node-preview__action--red" ng-click="vm.remove($index, $event)"><i class="icon icon-delete"></i></a>
+			</div>
+		</div>
+		<div class="picker-btn">
+			<button type="button" class="add-link btn-reset umb-outline umb-outline--surrounding add-link-square" ng-click="vm.add($event)" ng-hide="vm.allowMultiple === false && vm.items.length == 1"><i class="icon icon-add large"></i></button>
+		</div>
+		<input type="hidden" name="itemCount" ng-model="vm.items.length" val-property-validator="vm.validateMandatory" />
+	</ng-form>
 </div>


### PR DESCRIPTION
- Added some styles to make the property editor look close to the Umbraco media picker property
- Changed the "Add" button to become the link-square of the picker
- Changed the "Remove" link to the cross look and feel and positioned it above and on top of the preview box
- Re-positioned the sort icon/button to the top left of the preview box
- Reduced the size of the preview box to the same height as the media picker property but the width at a ratio of an HD size proportionally
- made all preview boxes as well as the "Add" button to align vertically
- New styles are referenced from a new stylesheet which has been called from the package.manifest