### PR TITLE
tweaks to allow the 'inter' value to be null or an empty string

### DIFF
--- a/src/Dawoe.OEmbedPickerPropertyEditor/ValueConverters/OEmbedPickerValueConverter.cs
+++ b/src/Dawoe.OEmbedPickerPropertyEditor/ValueConverters/OEmbedPickerValueConverter.cs
@@ -46,18 +46,16 @@
             object inter,
             bool preview)
         {
-            var allowMultipe = propertyType.DataType.ConfigurationAs<OEmbedPickerConfiguration>().AllowMultiple;
+            var allowMultiple = propertyType.DataType.ConfigurationAs<OEmbedPickerConfiguration>().AllowMultiple;
 
-            if (inter == null)
+            if (string.IsNullOrWhiteSpace(inter.ToString()))
             {
-                return allowMultipe ? Enumerable.Empty<OEmbedItem>() : null;
+                return allowMultiple ? Enumerable.Empty<OEmbedItem>() : null;
             }
 
-            var items = new List<OEmbedItem>();
+            var items = JsonConvert.DeserializeObject<List<OEmbedItem>>(inter.ToString());
 
-            items = JsonConvert.DeserializeObject<List<OEmbedItem>>(inter.ToString());
-
-            if (allowMultipe)
+            if (allowMultiple)
             {
                 return items;
             }


### PR DESCRIPTION
hi @dawoe as discussed in [https://github.com/dawoe/OEmbed-Picker-Property-Editor/issues/11](https://github.com/dawoe/OEmbed-Picker-Property-Editor/issues/11) this fixes the null exception issue 👍 