### PR TITLE
Change target to .NET and Umbraco 13, fixes #33

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 image: Visual Studio 2022
 
 # Version format
-version: 12.1.0.{build}
+version: 13.0.0.{build}
 
 branches:
   only:

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,12 +1,12 @@
 <Project>
 
   <PropertyGroup>
-    <TargetFrameworks>net7</TargetFrameworks>
+    <TargetFrameworks>net8</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Umbraco.Cms.Web.Website" Version="[12.0.0,13.0.0)" />
-    <PackageReference Include="Umbraco.Cms.Web.BackOffice" Version="[12.0.0,13.0.0)" />
+    <PackageReference Include="Umbraco.Cms.Web.Website" Version="[13.0.0,14.0.0)" />
+    <PackageReference Include="Umbraco.Cms.Web.BackOffice" Version="[13.0.0,14.0.0)" />
   </ItemGroup>
 
   <ItemGroup>
@@ -27,9 +27,9 @@
       <RepositoryType>git</RepositoryType>
       <Copyright>Copyright &amp;#169; Dave Woestenborghs and contributors.</Copyright>
       <PackageLicenseExpression>MIT</PackageLicenseExpression>
-      <AssemblyVersion>12.1.0</AssemblyVersion>
-      <VersionPrefix>12.1.0</VersionPrefix>
-      <InformationalVersion>12.1.0</InformationalVersion>
+      <AssemblyVersion>13.0.0</AssemblyVersion>
+      <VersionPrefix>13.0.0</VersionPrefix>
+      <InformationalVersion>13.0.0</InformationalVersion>
     </PropertyGroup>
 
 


### PR DESCRIPTION
This PR change the version to 13.0.0 and the target to .NET 8, adding support for Umbraco 13. 

I have not used multi-targeting, as per the commit to add Umbraco 12 support, although this would be entirely possible, given that there are no code changes.