### PR TITLE
Add a PropertyIndexValueFactory to index titles rather than surface Json in Examine

### DIFF
--- a/src/Dawoe.OEmbedPickerPropertyEditor.Core/OEmbedComposer.cs
+++ b/src/Dawoe.OEmbedPickerPropertyEditor.Core/OEmbedComposer.cs
@@ -1,4 +1,6 @@
 using Dawoe.OEmbedPickerPropertyEditor.Core.Migrations;
+using Dawoe.OEmbedPickerPropertyEditor.Core.ValueConverters;
+using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Notifications;
@@ -8,6 +10,9 @@ namespace Dawoe.OEmbedPickerPropertyEditor.Core
     internal sealed class OEmbedComposer : IComposer
     {
         public void Compose(IUmbracoBuilder builder)
-            => builder.AddNotificationAsyncHandler<UmbracoApplicationStartingNotification, RunMigrationsHandler>();
+        {
+            builder.AddNotificationAsyncHandler<UmbracoApplicationStartingNotification, RunMigrationsHandler>();
+            builder.Services.AddSingleton<IOEmbedPropertyIndexValueFactory, OEmbedPickerPropertyIndexValueFactory>();
+        }
     }
 }

--- a/src/Dawoe.OEmbedPickerPropertyEditor.Core/ValueConverters/OEmbedPickerPropertyEditor.cs
+++ b/src/Dawoe.OEmbedPickerPropertyEditor.Core/ValueConverters/OEmbedPickerPropertyEditor.cs
@@ -6,7 +6,7 @@ using Umbraco.Cms.Core.PropertyEditors;
 namespace Dawoe.OEmbedPickerPropertyEditor.Core.ValueConverters;
 
 [DataEditor(Constants.DataEditorAlias, ValueType = ValueTypes.Json)]
-public class OEmbedPickerPropertyEditor(IDataValueEditorFactory dataValueEditorFactory, IIOHelper ioHelper)
+public class OEmbedPickerPropertyEditor(IDataValueEditorFactory dataValueEditorFactory, IIOHelper ioHelper, IOEmbedPropertyIndexValueFactory oEmbedPropertyIndexValueFactory)
     : DataEditor(dataValueEditorFactory)
 {
     /// <inheritdoc />
@@ -16,5 +16,5 @@ public class OEmbedPickerPropertyEditor(IDataValueEditorFactory dataValueEditorF
     protected override IConfigurationEditor CreateConfigurationEditor() => new OEmbedPickerConfigurationEditor(ioHelper);
 
     /// <inheritdoc />
-    public override IPropertyIndexValueFactory PropertyIndexValueFactory => new OEmbedPickerPropertyIndexValueFactory();
+    public override IPropertyIndexValueFactory PropertyIndexValueFactory => oEmbedPropertyIndexValueFactory;
 }

--- a/src/Dawoe.OEmbedPickerPropertyEditor.Core/ValueConverters/OEmbedPickerPropertyEditor.cs
+++ b/src/Dawoe.OEmbedPickerPropertyEditor.Core/ValueConverters/OEmbedPickerPropertyEditor.cs
@@ -10,11 +10,11 @@ public class OEmbedPickerPropertyEditor(IDataValueEditorFactory dataValueEditorF
     : DataEditor(dataValueEditorFactory)
 {
     /// <inheritdoc />
+    public override IPropertyIndexValueFactory PropertyIndexValueFactory => oEmbedPropertyIndexValueFactory;
+
+    /// <inheritdoc />
     protected override IDataValueEditor CreateValueEditor() => this.DataValueEditorFactory.Create<OEmbedPickerPropertyValueEditor>(this.Attribute);
 
     /// <inheritdoc />
     protected override IConfigurationEditor CreateConfigurationEditor() => new OEmbedPickerConfigurationEditor(ioHelper);
-
-    /// <inheritdoc />
-    public override IPropertyIndexValueFactory PropertyIndexValueFactory => oEmbedPropertyIndexValueFactory;
 }

--- a/src/Dawoe.OEmbedPickerPropertyEditor.Core/ValueConverters/OEmbedPickerPropertyEditor.cs
+++ b/src/Dawoe.OEmbedPickerPropertyEditor.Core/ValueConverters/OEmbedPickerPropertyEditor.cs
@@ -14,4 +14,7 @@ public class OEmbedPickerPropertyEditor(IDataValueEditorFactory dataValueEditorF
 
     /// <inheritdoc />
     protected override IConfigurationEditor CreateConfigurationEditor() => new OEmbedPickerConfigurationEditor(ioHelper);
+
+    /// <inheritdoc />
+    public override IPropertyIndexValueFactory PropertyIndexValueFactory => new OEmbedPickerPropertyIndexValueFactory();
 }

--- a/src/Dawoe.OEmbedPickerPropertyEditor.Core/ValueConverters/OEmbedPickerPropertyIndexValueFactory.cs
+++ b/src/Dawoe.OEmbedPickerPropertyEditor.Core/ValueConverters/OEmbedPickerPropertyIndexValueFactory.cs
@@ -1,0 +1,86 @@
+// <copyright file="OEmbedPickerPropertyIndexValueFactory.cs" company="Umbraco community">
+// Copyright (c) Dave Woestenborghs and contributors. Licensed under the MIT License. See LICENSE in the project root for license information.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.PropertyEditors;
+
+namespace Dawoe.OEmbedPickerPropertyEditor.Core.ValueConverters;
+
+/// <summary>
+/// Provides index values for the OEmbed Picker property editor.
+/// </summary>
+public class OEmbedPickerPropertyIndexValueFactory : IPropertyIndexValueFactory
+{
+    private static readonly Regex IframeTitleRegex = new Regex(
+        @"title\s*=\s*[""']?([^""'\s>]+)[""']?",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    /// <inheritdoc />
+    public IEnumerable<IndexValue> GetIndexValues(
+        IProperty property,
+        string? culture,
+        string? segment,
+        bool published,
+        IEnumerable<string> availableCultures,
+        IDictionary<Guid, IContentType> contentTypeDictionary)
+    {
+        var propertyValue = property.GetValue(culture, segment, published);
+
+        if (propertyValue == null)
+        {
+            return [];
+        }
+
+        // The property value is JSON - try to extract titles from all embeds
+        var titles = new List<string>();
+
+        if (propertyValue is string jsonString && !string.IsNullOrWhiteSpace(jsonString))
+        {
+            try
+            {
+                // The JSON is an array of OEmbed items
+                using var doc = JsonDocument.Parse(jsonString);
+                if (doc.RootElement.ValueKind == JsonValueKind.Array)
+                {
+                    foreach (var element in doc.RootElement.EnumerateArray())
+                    {
+                        if (element.TryGetProperty("preview", out var previewElement))
+                        {
+                            var preview = previewElement.GetString();
+                            if (!string.IsNullOrWhiteSpace(preview))
+                            {
+                                // Extract title from the iframe tag
+                                var match = IframeTitleRegex.Match(preview);
+                                if (match.Success)
+                                {
+                                    titles.Add(match.Groups[1].Value);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            catch
+            {
+                // If JSON parsing fails, ignore
+            }
+        }
+
+        // Return a single combined field with all titles (if any found)
+        return
+        [
+            new IndexValue
+            {
+                Culture = culture,
+                FieldName = property.Alias,
+                Values = titles.Count > 0 ? titles.ToArray() : []
+            }
+        ];
+    }
+}

--- a/src/Dawoe.OEmbedPickerPropertyEditor.Core/ValueConverters/OEmbedPickerPropertyIndexValueFactory.cs
+++ b/src/Dawoe.OEmbedPickerPropertyEditor.Core/ValueConverters/OEmbedPickerPropertyIndexValueFactory.cs
@@ -1,28 +1,66 @@
-// <copyright file="OEmbedPickerPropertyIndexValueFactory.cs" company="Umbraco community">
-// Copyright (c) Dave Woestenborghs and contributors. Licensed under the MIT License. See LICENSE in the project root for license information.
-// </copyright>
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.Json;
 using System.Text.RegularExpressions;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Serialization;
 
 namespace Dawoe.OEmbedPickerPropertyEditor.Core.ValueConverters;
 
 /// <summary>
 /// Provides index values for the OEmbed Picker property editor.
 /// </summary>
-public class OEmbedPickerPropertyIndexValueFactory : IPropertyIndexValueFactory
+public class OEmbedPickerPropertyIndexValueFactory : JsonPropertyIndexValueFactoryBase<OEmbedIndexItem[]>, IOEmbedPropertyIndexValueFactory
 {
     private static readonly Regex IframeTitleRegex = new Regex(
-        @"title\s*=\s*[""']?([^""'\s>]+)[""']?",
-        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    @"title\s*=\s*[""']([^""']+)[""']",
+    RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private readonly IJsonSerializer _jsonSerializer;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OEmbedPickerPropertyIndexValueFactory"/> class.
+    /// </summary>
+    /// <param name="jsonSerializer">The JSON serializer.</param>
+    /// <param name="indexingSettings">The indexing settings.</param>
+    public OEmbedPickerPropertyIndexValueFactory(
+        IJsonSerializer jsonSerializer,
+        IOptionsMonitor<IndexingSettings> indexingSettings)
+        : base(jsonSerializer, indexingSettings)
+    {
+        _jsonSerializer = jsonSerializer;
+    }
+
+    public override IEnumerable<IndexValue> GetIndexValues(
+    IProperty property,
+    string? culture,
+    string? segment,
+    bool published,
+    IEnumerable<string> availableCultures,
+    IDictionary<Guid, IContentType> contentTypeDictionary)
+    {
+        // Manually pull the value to ensure we aren't being filtered out
+        var val = property.GetValue(culture, segment, published);
+
+        if (val is string json && !string.IsNullOrWhiteSpace(json))
+        {
+            var deserialized = _jsonSerializer.Deserialize<OEmbedIndexItem[]>(json);
+            if (deserialized != null)
+            {
+                // Call your Handle method
+                return Handle(deserialized, property, culture, segment, published, availableCultures, contentTypeDictionary);
+            }
+        }
+
+        return Array.Empty<IndexValue>();
+    }
 
     /// <inheritdoc />
-    public IEnumerable<IndexValue> GetIndexValues(
+    protected override IEnumerable<IndexValue> Handle(
+        OEmbedIndexItem[] deserializedPropertyValue,
         IProperty property,
         string? culture,
         string? segment,
@@ -30,57 +68,53 @@ public class OEmbedPickerPropertyIndexValueFactory : IPropertyIndexValueFactory
         IEnumerable<string> availableCultures,
         IDictionary<Guid, IContentType> contentTypeDictionary)
     {
-        var propertyValue = property.GetValue(culture, segment, published);
-
-        if (propertyValue == null)
-        {
-            return [];
-        }
-
-        // The property value is JSON - try to extract titles from all embeds
         var titles = new List<string>();
 
-        if (propertyValue is string jsonString && !string.IsNullOrWhiteSpace(jsonString))
+        foreach (var item in deserializedPropertyValue ?? Array.Empty<OEmbedIndexItem>())
         {
-            try
+            if (!string.IsNullOrWhiteSpace(item.Preview))
             {
-                // The JSON is an array of OEmbed items
-                using var doc = JsonDocument.Parse(jsonString);
-                if (doc.RootElement.ValueKind == JsonValueKind.Array)
+                var match = IframeTitleRegex.Match(item.Preview);
+                if (match.Success)
                 {
-                    foreach (var element in doc.RootElement.EnumerateArray())
-                    {
-                        if (element.TryGetProperty("preview", out var previewElement))
-                        {
-                            var preview = previewElement.GetString();
-                            if (!string.IsNullOrWhiteSpace(preview))
-                            {
-                                // Extract title from the iframe tag
-                                var match = IframeTitleRegex.Match(preview);
-                                if (match.Success)
-                                {
-                                    titles.Add(match.Groups[1].Value);
-                                }
-                            }
-                        }
-                    }
+                    titles.Add(match.Groups[1].Value);
                 }
-            }
-            catch
-            {
-                // If JSON parsing fails, ignore
             }
         }
 
-        // Return a single combined field with all titles (if any found)
-        return
-        [
-            new IndexValue
-            {
-                Culture = culture,
-                FieldName = property.Alias,
-                Values = titles.Count > 0 ? titles.ToArray() : []
-            }
-        ];
+        if (titles.Count == 0)
+        {
+            yield break; // Don't add anything to the index if no titles found
+        }
+
+        yield return new IndexValue
+        {
+            Culture = culture,
+            FieldName = property.Alias,
+            Values = titles,
+        };
     }
+
+
+}
+
+/// <summary>
+/// DTO for deserializing OEmbed items from the property value JSON.
+/// </summary>
+public class OEmbedIndexItem
+{
+    public string? Url { get; set; }
+
+    public string? Preview { get; set; }
+}
+
+/// <summary>
+///     Represents a property index value factory specifically for OEmbed properties.
+/// </summary>
+/// <remarks>
+///     This marker interface allows for specialized indexing of OEmbed values,
+///     enabling proper handling of multiple Oembed values per property.
+/// </remarks>
+public interface IOEmbedPropertyIndexValueFactory : IPropertyIndexValueFactory
+{
 }


### PR DESCRIPTION
I noticed that the property editor was missing a `PropertyIndexValueFactory` and so was defaulting to exposing JSON in the examine index.

<img width="1008" height="479" alt="image" src="https://github.com/user-attachments/assets/d18bcf86-e41b-4eb6-b699-7e1b7df246a2" />


I've added one based on the `JsonPropertyIndexValueFactoryBase` that we can see in the tags core implementation. https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Core/PropertyEditors/TagPropertyIndexValueFactory.cs


For Youtube and Vimeo it extracts the title.. and indexes that, I've tested for standard propeditor and in the grid, and also when `ExplicitlyIndexEachNestedProperty` and seem to surface the titles in all instances. (might also want to index the vimeo/youtube guids.. but not sure how useful that is..)


<img width="739" height="305" alt="image" src="https://github.com/user-attachments/assets/aa1b3a6c-bcc6-4326-b574-a92579259a70" />



PS at present I am overriding in my project.. (with the OEmbedPickerPropertyIndexValueFactory from the pr) and seems to work in production
```c#
    [ComposeAfter(typeof(OEmbedComposer))]
    internal sealed class OEmbedComposer : IComposer
    {
        public void Compose(IUmbracoBuilder builder)
        {
            builder.Services.AddSingleton<IOEmbedPropertyIndexValueFactory, OEmbedPickerPropertyIndexValueFactory>();

            // We remove the original by type and add our new one (DataEditor annotations do autodiscovery, but belt and braces)
            builder.DataEditors().Exclude<ValueConverters.OEmbedPickerPropertyEditor>();
            builder.DataEditors().Add<SmOEmbedPickerPropertyEditor>();
        }
    }
```
```c#
// Ensure the alias matches the one you are overriding
[DataEditor(Dawoe.OEmbedPickerPropertyEditor.Core.Constants.DataEditorAlias, ValueType = ValueTypes.Json)]
public class SmOEmbedPickerPropertyEditor(
    IDataValueEditorFactory dataValueEditorFactory,
    IIOHelper ioHelper,
    IOEmbedPropertyIndexValueFactory oEmbedPropertyIndexValueFactory)
    : DataEditor(dataValueEditorFactory)
{
    protected override IDataValueEditor CreateValueEditor() =>
        DataValueEditorFactory.Create<OEmbedPickerPropertyValueEditor>(Attribute);

    protected override IConfigurationEditor CreateConfigurationEditor() =>
        new OEmbedPickerConfigurationEditor(ioHelper);

    public override IPropertyIndexValueFactory PropertyIndexValueFactory => oEmbedPropertyIndexValueFactory;
}
```